### PR TITLE
allow continuing execution

### DIFF
--- a/src/component/_generated/dataModel.ts
+++ b/src/component/_generated/dataModel.ts
@@ -38,7 +38,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * Convex documents are uniquely identified by their `Id`, which is accessible
  * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
  *
- * Documents can be loaded using `db.get(id)` in query and mutation functions.
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.

--- a/src/component/_generated/server.ts
+++ b/src/component/_generated/server.ts
@@ -107,11 +107,6 @@ export const internalAction: ActionBuilder<DataModel, "internal"> =
  */
 export const httpAction: HttpActionBuilder = httpActionGeneric;
 
-type GenericCtx =
-  | GenericActionCtx<DataModel>
-  | GenericMutationCtx<DataModel>
-  | GenericQueryCtx<DataModel>;
-
 /**
  * A set of services for use within Convex query functions.
  *

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -318,3 +318,35 @@ export const rescheduler = internalMutation({
     );
   },
 });
+
+export const continueExecution = mutation({
+  args: {
+    id: v.id("crons"),
+    functionHandle: v.string(),
+    args: v.any(),
+  },
+  handler: async (ctx, { id, functionHandle, args }) => {
+    const cronJob = await ctx.db.get("crons", id);
+    if (!cronJob) {
+      throw Error(`Cron ${id} not found`);
+    }
+    if (!cronJob.executionJobId) {
+      throw Error(`Job not executing ${id}`);
+    }
+    const executionJob = await ctx.db.system.get(
+      "_scheduled_functions",
+      cronJob.executionJobId,
+    );
+    if (!executionJob || executionJob.state.kind !== "inProgress") {
+      throw Error(
+        `Execution job ${cronJob.executionJobId} expected to still be running`,
+      );
+    }
+    const executionJobId = await ctx.scheduler.runAfter(
+      0,
+      functionHandle as FunctionHandle<"mutation" | "action">,
+      args,
+    );
+    await ctx.db.patch("crons", id, { executionJobId });
+  },
+});


### PR DESCRIPTION
Allow a mutation that's recursively scheduling more work to be done to be considered still "running" from the perspective of the crons scheduler, to avoid it being started another time.