### PR TITLE
expand ctx types to support mutations and actions

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -8,7 +8,7 @@ import {
 } from "convex/server";
 import type { ComponentApi } from "../component/_generated/component.js";
 import type { CronInfo, Schedule } from "../component/public.js";
-import type { RunMutationCtx, RunQueryCtx } from "./utils.js";
+import type { ActionCtx, MutationCtx, QueryCtx } from "./utils.js";
 
 export type { CronInfo };
 
@@ -67,7 +67,7 @@ export class Crons {
    * @returns A string identifier for the cron job.
    */
   async register<F extends SchedulableFunctionReference>(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     schedule: Schedule,
     func: F,
     args: FunctionArgs<F>,
@@ -86,7 +86,7 @@ export class Crons {
    *
    * @returns List of `cron` table rows.
    */
-  async list(ctx: RunQueryCtx): Promise<CronInfo[]> {
+  async list(ctx: QueryCtx | MutationCtx | ActionCtx): Promise<CronInfo[]> {
     const crons = await ctx.runQuery(this.component.public.list, {});
     return crons.map((cron) => ({
       ...cron,
@@ -103,7 +103,7 @@ export class Crons {
    * @returns Cron job document.
    */
   async get(
-    ctx: RunQueryCtx,
+    ctx: QueryCtx | MutationCtx | ActionCtx,
     identifier: { id: string } | { name: string },
   ): Promise<CronInfo | null> {
     const cron = await ctx.runQuery(this.component.public.get, { identifier });
@@ -124,7 +124,7 @@ export class Crons {
    * @param identifier - Either the ID or name of the cron job.
    */
   async delete(
-    ctx: RunMutationCtx,
+    ctx: MutationCtx | ActionCtx,
     identifier: { id: string } | { name: string },
   ): Promise<null> {
     return ctx.runMutation(this.component.public.del, { identifier });

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,12 +1,16 @@
 import type {
+  GenericActionCtx,
   GenericDataModel,
   GenericMutationCtx,
   GenericQueryCtx,
 } from "convex/server";
 
-export type RunQueryCtx = {
-  runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];
-};
-export type RunMutationCtx = {
-  runMutation: GenericMutationCtx<GenericDataModel>["runMutation"];
-};
+export type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
+export type MutationCtx = Pick<
+  GenericMutationCtx<GenericDataModel>,
+  "runQuery" | "runMutation"
+>;
+export type ActionCtx = Pick<
+  GenericActionCtx<GenericDataModel>,
+  "runQuery" | "runMutation" | "runAction"
+>;


### PR DESCRIPTION
The context types accepted by `Crons` methods have been updated to be more flexible and accurate.

Previously, `RunQueryCtx` and `RunMutationCtx` were minimal types exposing only a single method each. They have been replaced with `QueryCtx`, `MutationCtx`, and `ActionCtx` types that reflect the actual Convex context shapes more closely, using `Pick` to expose the relevant methods from their respective generic context types.

Methods that previously accepted only `RunQueryCtx` (`list`, `get`) now accept `QueryCtx | MutationCtx | ActionCtx`, and methods that previously accepted only `RunMutationCtx` (`register`, `delete`) now accept `MutationCtx | ActionCtx`. This allows callers to pass any of the standard Convex context types without needing to manually satisfy a narrow interface.